### PR TITLE
Fix adding event listeners

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,268 +8,272 @@ Use the JavaScript API to manipulate the chat widget displayed on your website.
 <br/>
 
 ## Table of contents
-- [load](#load)
-- [statusChange](#statuschange)
-- [beforeLoad](#beforeload)
-- [chatMaximized](#chatmaximized)
-- [chatMinimized](#chatminimized)
-- [chatHidden](#chathidden)
-- [chatStarted](#chatstarted)
-- [chatEnded](#chatended)
-- [prechatSubmit](#prechatsubmit)
-- [offlineSubmit](#offlinesubmit)
-- [chatMessageVisitor](#chatmessagevisitor)
-- [chatMessageAgent](#chatmessageagent)
-- [chatMessageSystem](#chatmessagesystem)
-- [agentJoinChat](#agentjoinchat)
-- [agentLeaveChat](#agentleavechat)
-- [chatSatisfaction](#chatsatisfaction)
-- [visitorNameChanged](#visitornamechanged)
-- [fileUpload](#fileupload)
-- [tagsUpdated](#tagsupdated)
-- [unreadCountChanged](#unreadcountchanged)
-- [visitor](#visitor)
-- [maximize](#maximize)
-- [minimize](#minimize)
-- [toggle](#toggle)
-- [popup](#popup)
-- [getWindowType](#getwindowtype)
-- [showWidget](#showwidget)
-- [hideWidget](#hidewidget)
-- [toggleVisibility](#togglevisibility)
-- [getStatus](#getstatus)
-- [isChatMaximized](#ischatmaximized)
-- [isChatMinimized](#ischatminimized)
-- [isChatHidden](#ischathidden)
-- [isChatOngoing](#ischatongoing)
-- [isVisitorEngaged](#isvisitorengaged)
-- [onLoaded](#onloaded)
-- [onBeforeLoaded](#onbeforeloaded)
-- [widgetPosition](#widgetposition)
-- [endChat](#endchat)
-- [setAttributes](#setattributes)
-- [addEvent](#addevent)
-- [addTags](#addtags)
-- [removeTags](#removetags)
-- [secureMode](#securemode)
-- [customStyle](#customstyle)
+- [API Reference](#api-reference)
+  - [Table of contents](#table-of-contents)
+  - [onLoad](#onload)
+  - [onStatusChange](#onstatuschange)
+  - [onBeforeLoad](#onbeforeload)
+  - [onChatMaximized](#onchatmaximized)
+  - [onChatMinimized](#onchatminimized)
+  - [onChatHidden](#onchathidden)
+  - [onChatStarted](#onchatstarted)
+  - [onChatEnded](#onchatended)
+  - [onPrechatSubmit](#onprechatsubmit)
+  - [onOfflineSubmit](#onofflinesubmit)
+  - [onChatMessageVisitor](#onchatmessagevisitor)
+  - [onChatMessageAgent](#onchatmessageagent)
+  - [onChatMessageSystem](#onchatmessagesystem)
+  - [onAgentJoinChat](#onagentjoinchat)
+  - [onAgentLeaveChat](#onagentleavechat)
+  - [onChatSatisfaction](#onchatsatisfaction)
+  - [onVisitorNameChanged](#onvisitornamechanged)
+  - [onFileUpload](#onfileupload)
+  - [onTagsUpdated](#ontagsupdated)
+  - [onUnreadCountChanged](#onunreadcountchanged)
+  - [visitor](#visitor)
+  - [maximize](#maximize)
+  - [minimize](#minimize)
+  - [toggle](#toggle)
+  - [popup](#popup)
+  - [getWindowType](#getwindowtype)
+  - [showWidget](#showwidget)
+  - [hideWidget](#hidewidget)
+  - [toggleVisibility](#togglevisibility)
+  - [getStatus](#getstatus)
+  - [isChatMaximized](#ischatmaximized)
+  - [isChatMinimized](#ischatminimized)
+  - [isChatHidden](#ischathidden)
+  - [isChatOngoing](#ischatongoing)
+  - [isVisitorEngaged](#isvisitorengaged)
+  - [onLoaded](#onloaded)
+  - [onBeforeLoaded](#onbeforeloaded)
+  - [widgetPosition](#widgetposition)
+  - [endChat](#endchat)
+  - [setAttributes](#setattributes)
+  - [addEvent](#addevent)
+  - [addTags](#addtags)
+  - [removeTags](#removetags)
+  - [secureMode](#securemode)
+  - [customstyle](#customstyle)
+    - [zIndex](#zindex)
+    - [Visibility](#visibility)
 
 <br/>
 
-## load
-Listen on event that invoked right after the widget is rendered. This is not supported in pop out chat window.
+## onLoad
+Callback function invoked right after the widget is rendered. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('load', () => {
+this.$tawkMessenger.onLoad(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## statusChange
-Listen on event that invoked when the page status changes. The function will receive the changed status which will be either online, away or offline. This is not supported in pop out chat window.
+## onStatusChange
+Callback function invoked when the page status changes. The function will receive the changed status which will be either online, away or offline. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('statusChage', (status) => {
+this.$tawkMessenger.onStatusChage((status) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## beforeLoad
-Listen on event that invoked right when Tawk_API is ready to be used and before the widget is rendered. This is not supported in pop out chat window.
+## onBeforeLoad
+Callback function invoked right when Tawk_API is ready to be used and before the widget is rendered. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('beforeLoad', () => {
+this.$tawkMessenger.onBeforeLoad(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatMaximized
-Listen on event that invoked when the widget is maximized. This is not supported in pop out chat window.
+## onChatMaximized
+Callback function invoked when the widget is maximized. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatMaximized', () => {
+this.$tawkMessenger.onChatMaximized(() => {
     // place your code here
 })
 ```
 
 <br/>
 
-## chatMinimized
-Listen on event that invoked when the widget is minimized. This is not supported in pop out chat window.
+## onChatMinimized
+Callback function invoked when the widget is minimized. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatMinimized', () => {
+this.$tawkMessenger.onChatMinimized(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatHidden
-Listen on event that invoked when the widget is hidden. This is not supported in pop out chat window.
+## onChatHidden
+Callback function invoked when the widget is hidden. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatHidden', () => {
+this.$tawkMessenger.onChatHidden(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatStarted
-Listen on event that invoked when the widget is started.
+## onChatStarted
+Callback function invoked when the widget is started.
 
 ```js
-this.$tawkMessenger.$on('chatStarted', () => {
+this.$tawkMessenger.onChatStarted(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatEnded
-Listen on event that invoked when the widget is ended. This is not supported in pop out chat window.
+## onChatEnded
+Callback function invoked when the widget is ended. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatEnded', () => {
+this.$tawkMessenger.onChatEnded(() => {
     // place your code here
 });
 ```
 
 <br/>
 
-## prechatSubmit
-Listen on event that invoked when the Pre-Chat Form is submitted. The submitted form data is passed to the function. This is not supported in pop out chat window.
+## onPrechatSubmit
+Callback function invoked when the Pre-Chat Form is submitted. The submitted form data is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('prechatSubmit', (data) => {
+this.$tawkMessenger.onPrechatSubmit((data) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## offlineSubmit
-Listen on event that invoked when the Offline form is submitted. The submitted form data is passed to the function. Form data will contain {name : ”, email : ”, message : ”, questions : []}. This is not supported in pop out chat window.
+## onOfflineSubmit
+Callback function invoked when the Offline form is submitted. The submitted form data is passed to the function. Form data will contain {name : ”, email : ”, message : ”, questions : []}. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('offlineSubmit', (data) => {
+this.$tawkMessenger.onOfflineSubmit((data) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatMessageVisitor
-Listen on event that invoked when message is sent by the visitor. The message is passed to the function. This is not supported in pop out chat window.
+## onChatMessageVisitor
+Callback function invoked when message is sent by the visitor. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatMessageVisitor', (message) => {
+this.$tawkMessenger.onChatMessageVisitor((message) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatMessageAgent
-Listen on event that invoked when message is sent by the agent. The message is passed to the function. This is not supported in pop out chat window.
+## onChatMessageAgent
+Callback function invoked when message is sent by the agent. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatMessageAgent', (message) => {
+this.$tawkMessenger.onChatMessageAgent((message) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatMessageSystem
-Listen on event that invoked when message is sent by the system. The message is passed to the function. This is not supported in pop out chat window.
+## onChatMessageSystem
+Callback function invoked when message is sent by the system. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatMessageSystem', (message) => {
+this.$tawkMessenger.onChatMessageSystem((message) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## agentJoinChat
-Listen on event that invoked when an agent joins the chat. The data is passed to the function. Will contain {name : ”, position : ”, image : ”, id : ”}. This is not supported in pop out chat window.
+## onAgentJoinChat
+Callback function invoked when an agent joins the chat. The data is passed to the function. Will contain {name : ”, position : ”, image : ”, id : ”}. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('agentJoinChat', (data) => {
+this.$tawkMessenger.onAgentJoinChat((data) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## agentLeaveChat
-Listen on event that invoked when an agent leaves the chat. The data is passed to the function. Will contain {name : ”, id : ”}. This is not supported in pop out chat window.
+## onAgentLeaveChat
+Callback function invoked when an agent leaves the chat. The data is passed to the function. Will contain {name : ”, id : ”}. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('agentLeaveChat', (data) => {
+this.$tawkMessenger.onAgentLeaveChat((data) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## chatSatisfaction
-Listen on event that invoked when an agent leaves the chat. The satisfaction is passed to the function. -1 = dislike | 0 = neutral | 1 = like. This is not supported in pop out chat window.
+## onChatSatisfaction
+Callback function invoked when an agent leaves the chat. The satisfaction is passed to the function. -1 = dislike | 0 = neutral | 1 = like. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('chatSatisfaction', (satisfaction) => {
+this.$tawkMessenger.onChatSatisfaction((satisfaction) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## visitorNameChanged
-Listen on event that invoked when the visitor manually changes his name. The visitorName is passed to the function. This is not supported in pop out chat window.
+## onVisitorNameChanged
+Callback function invoked when the visitor manually changes his name. The visitorName is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('visitorNameChanged', (visitorName) => {
+this.$tawkMessenger.onVisitorNameChanged((visitorName) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## fileUpload
-Listen on event that invoked when a file is uploaded. The link to the uploaded file is passed to the function. This is not supported in pop out chat window.
+## onFileUpload
+Callback function invoked when a file is uploaded. The link to the uploaded file is passed to the function. This callback is not supported in pop out chat window.
 
 ```js
-this.$tawkMessenger.$on('fileUpload', (link) => {
+this.$tawkMessenger.onFileUpload((link) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## tagsUpdated
-Listen on event that invoked when a tag is updated.
+## onTagsUpdated
+Callback function invoked when a tag is updated.
 
 ```js
-this.$tawkMessenger.$on('tagsUpdated', (data) => {
+this.$tawkMessenger.onTagsUpdated((data) => {
     // place your code here
 });
 ```
 
 <br/>
 
-## unreadCountChanged
-Listen on event that returns count of unread messages.
+## onUnreadCountChanged
+Callback function returns count of unread messages.
 
 ```js
-this.$tawkMessenger.$on('unreadCountChanged', (count) => {
+this.$tawkMessenger.onUnreadCountChanged((count) => {
     // place your code here
 });
 ```

--- a/docs/spa-setup.md
+++ b/docs/spa-setup.md
@@ -14,11 +14,11 @@ this.$tawkMessenger.toggle();
 <br/>
 
 ## Event handling
-You can listen on events emitted by the plugin, It must be exactly match the name used to listen
+You can add a callback on event listeners, It must be exactly match the name used to listen
 to that event, you can see the list of [events](api-reference.md) here.
 
 ```js
-this.$tawkMessenger.$on('load', () => {
+this.$tawkMessenger.onLoad(() => {
     // place your code here
 });
 ```

--- a/docs/ssr-setup.md
+++ b/docs/ssr-setup.md
@@ -49,11 +49,11 @@ this.$tawkMessenger.toggle();
 <br/>
 
 ## Event handling
-You can listen on events emitted by the plugin, It must be exactly match the name used to listen
+You can add a callback on event listeners, It must be exactly match the name used to listen
 to that event.
 
 ```js
-this.$tawkMessenger.$on('load', () => {
+this.$tawkMessenger.onLoad(() => {
     // place your code here
 });
 ```

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -96,85 +96,125 @@ class TawkMessenger {
 	 * inside of the widget
 	 */
 	mapListeners() {
-		window.addEventListener('tawkLoad', () => {
-			this.root.$emit('load');
-		});
-
-		window.addEventListener('tawkStatusChange', (status) => {
-			this.root.$emit('statusChange', status.detail);
-		});
-
-		window.addEventListener('tawkBeforeLoad', () => {
-			this.root.$emit('beforeLoad');
-		});
-
-		window.addEventListener('tawkChatMaximized', () => {
-			this.root.$emit('chatMaximized');
-		});
-
-		window.addEventListener('tawkChatMinimized', () => {
-			this.root.$emit('chatMinimized');
-		});
-
-		window.addEventListener('tawkChatHidden', () => {
-			this.root.$emit('chatHidden');
-		});
-
-		window.addEventListener('tawkChatStarted', () => {
-			this.root.$emit('chatStarted');
-		});
-
-		window.addEventListener('tawkChatEnded', () => {
-			this.root.$emit('chatEnded');
-		});
-
-		window.addEventListener('tawkPrechatSubmit', (data) => {
-			this.root.$emit('prechatSubmit', data.detail);
-		});
-
-		window.addEventListener('tawkOfflineSubmit', (data) => {
-			this.root.$emit('offlineSubmit', data.detail);
-		});
+		this.root.onLoad = (event) => {
+			window.addEventListener('tawkLoad', () => {
+				event();
+			});
+		};
 		
-		window.addEventListener('tawkChatMessageVisitor', (message) => {
-			this.root.$emit('chatMessageVisitor', message.detail);
-		});
+		this.root.onStatusChange = (event) => {
+			window.addEventListener('tawkStatusChange', (status) => {
+				event(status.detail);
+			});
+		};
 
-		window.addEventListener('tawkChatMessageAgent', (message) => {
-			this.root.$emit('chatMessageAgent', message.detail);
-		});
+		this.root.onBeforeLoad = (event) => {
+			window.addEventListener('tawkBeforeLoad', () => {
+				event();
+			});
+		};
 
-		window.addEventListener('tawkChatMessageSystem', (message) => {
-			this.root.$emit('chatMessageSystem', message.detail);
-		});
+		this.root.onChatMaximized = (event) => {
+			window.addEventListener('tawkChatMaximized', () => {
+				event();
+			});
+		};
 
-		window.addEventListener('tawkAgentJoinChat', (data) => {
-			this.root.$emit('agentJoinChat', data.detail);
-		});
+		this.root.onChatMinimized = (event) => {
+			window.addEventListener('tawkChatMinimized', () => {
+				event();
+			});
+		};
+
+		this.root.onChatHidden = (event) => {
+			window.addEventListener('tawkChatHidden', () => {
+				event('chatHidden');
+			});
+		};
 		
-		window.addEventListener('tawkAgentLeaveChat', (data) => {
-			this.root.$emit('agentLeaveChat', data.detail);
-		});
+		this.root.onChatStarted = (event) => {
+			window.addEventListener('tawkChatStarted', () => {
+				event();
+			});
+		};
 
-		window.addEventListener('tawkChatSatisfaction', (satisfaction) => {
-			this.root.$emit('chatSatisfaction', satisfaction.detail);
-		});
-		
-		window.addEventListener('tawkVisitorNameChanged', (visitorName) => {
-			this.root.$emit('visitorNameChanged', visitorName.detail);
-		});
+		this.root.onChatEnded = (event) => {
+			window.addEventListener('tawkChatEnded', () => {
+				event();
+			});
+		};
 
-		window.addEventListener('tawkFileUpload', (link) => {
-			this.root.$emit('fileUpload', link.detail);
-		});
+		this.root.onPrechatSubmit = (event) => {
+			window.addEventListener('tawkPrechatSubmit', (data) => {
+				event('prechatSubmit', data.detail);
+			});
+		};
 
-		window.addEventListener('tawkTagsUpdated', (data) => {
-			this.root.$emit('tagsUpdated', data.detail);
-		});
+		this.root.onOfflineSubmit = (event) => {
+			window.addEventListener('tawkOfflineSubmit', (data) => {
+				event(data.detail);
+			});
+		};
 
-		window.addEventListener('tawkUnreadCountChanged', (data) => {
-			this.root.$emit('unreadCountChanged', data.detail);
-		});
+		this.root.onChatMessageVisitor = (event) => {
+			window.addEventListener('tawkChatMessageVisitor', (message) => {
+				event(message.detail);
+			});
+		};
+
+		this.root.onChatMessageAgent = (event) => {
+			window.addEventListener('tawkChatMessageAgent', (message) => {
+				event(message.detail);
+			});
+		};
+
+		this.root.onChatMessageSystem = (event) => {
+			window.addEventListener('tawkChatMessageSystem', (message) => {
+				event(message.detail);
+			});
+		};
+
+		this.root.onAgentJoinChat = (event) => {
+			window.addEventListener('tawkAgentJoinChat', (data) => {
+				event(data.detail);
+			});
+		};
+
+		this.root.onAgentLeaveChat = (event) => {
+			window.addEventListener('tawkAgentLeaveChat', (data) => {
+				event(data.detail);
+			});
+		};
+
+		this.root.onChatSatisfaction = (event) => {
+			window.addEventListener('tawkChatSatisfaction', (satisfaction) => {
+				event(satisfaction.detail);
+			});
+		};
+
+		this.root.onVisitorNameChanged = (event) => {
+			window.addEventListener('tawkVisitorNameChanged', (visitorName) => {
+				event(visitorName.detail);
+			});
+		};
+
+		this.root.onFileUpload = (event) => {
+			window.addEventListener('tawkFileUpload', (link) => {
+				event(link.detail);
+			});
+		};
+
+		this.root.onTagsUpdated = (event) => {
+			window.addEventListener('tawkTagsUpdated', (data) => {
+				event(data.detail);
+			});
+		};
+
+		this.root.onUnreadCountChanged = (event) => {
+			window.addEventListener('tawkUnreadCountChanged', (data) => {
+				event(data.detail);
+			});
+		};
 	}
 
 	/**

--- a/tests/unit/tawk-messenger.spec.js
+++ b/tests/unit/tawk-messenger.spec.js
@@ -6,7 +6,6 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import TawkMessengerVue from '../../src';
 
 describe('Tawk-messenger plugin', () => {
-	let mountApp;
 	const localVue = createLocalVue();
 
 	/**
@@ -24,86 +23,192 @@ describe('Tawk-messenger plugin', () => {
 		template : '<div></div>'
 	});
 
-	beforeEach(() => {
-		mountApp = () => mount(EmptyComponent, { localVue });
-	});
+	const wrapper = () => mount(EmptyComponent, { localVue });
+	const $tawkMessenger = wrapper().vm.$tawkMessenger;
 
 	describe('Initialize', () => {
 		it('Should set the Tawk_API global variable.', () => {
-			mountApp();
-
 			expect(typeof window.Tawk_API === 'object').toBe(true);
 		});
 
 		it('Should set Instance property $tawkMessenger', () => {
-			const wrapper = mountApp();
-
-			expect(typeof wrapper.vm.$tawkMessenger === 'object').toBe(true);
+			expect(typeof $tawkMessenger === 'object').toBe(true);
 		});
 	});
 
 	describe('API', () => {
 		it('Should set the action functions.', () => {
-			const wrapper = mountApp();
-
-			expect(typeof wrapper.vm.$tawkMessenger.maximize === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.minimize === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.toggle === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.popup === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.showWidget === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.hideWidget === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.toggleVisibility === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.endChat === 'function').toBe(true);
+			expect(typeof $tawkMessenger.maximize === 'function').toBe(true);
+			expect(typeof $tawkMessenger.minimize === 'function').toBe(true);
+			expect(typeof $tawkMessenger.toggle === 'function').toBe(true);
+			expect(typeof $tawkMessenger.popup === 'function').toBe(true);
+			expect(typeof $tawkMessenger.showWidget === 'function').toBe(true);
+			expect(typeof $tawkMessenger.hideWidget === 'function').toBe(true);
+			expect(typeof $tawkMessenger.toggleVisibility === 'function').toBe(true);
+			expect(typeof $tawkMessenger.endChat === 'function').toBe(true);
 		});
 
 		it('Should set the getters functions.', () => {
-			const wrapper = mountApp();
-
-			expect(typeof wrapper.vm.$tawkMessenger.getWindowType === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.getStatus === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.isChatMaximized === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.isChatMinimized === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.isChatHidden === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.isChatOngoing === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.isVisitorEngaged === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.onLoaded === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.onBeforeLoaded === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.widgetPosition === 'function').toBe(true);
+			expect(typeof $tawkMessenger.getWindowType === 'function').toBe(true);
+			expect(typeof $tawkMessenger.getStatus === 'function').toBe(true);
+			expect(typeof $tawkMessenger.isChatMaximized === 'function').toBe(true);
+			expect(typeof $tawkMessenger.isChatMinimized === 'function').toBe(true);
+			expect(typeof $tawkMessenger.isChatHidden === 'function').toBe(true);
+			expect(typeof $tawkMessenger.isChatOngoing === 'function').toBe(true);
+			expect(typeof $tawkMessenger.isVisitorEngaged === 'function').toBe(true);
+			expect(typeof $tawkMessenger.onLoaded === 'function').toBe(true);
+			expect(typeof $tawkMessenger.onBeforeLoaded === 'function').toBe(true);
+			expect(typeof $tawkMessenger.widgetPosition === 'function').toBe(true);
 		});
 
-		it('Should set the event listeners.', () => {
-			mountApp();
+		describe('Should set the event listeners.', () => {
+			it('should add tawkLoad event listener', () => {
+				expect(typeof $tawkMessenger.onLoad === 'function').toBe(true);
 
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkLoad', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkStatusChange', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkBeforeLoad', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMaximized', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMinimized', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatHidden', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatStarted', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatEnded', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkPrechatSubmit', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkOfflineSubmit', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageVisitor', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageAgent', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageSystem', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkAgentJoinChat', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkAgentLeaveChat', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkChatSatisfaction', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkVisitorNameChanged', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkFileUpload', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkTagsUpdated', expect.any(Function));
-			expect(window.addEventListener).toHaveBeenCalledWith('tawkUnreadCountChanged', expect.any(Function));
+				$tawkMessenger.onLoad(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkLoad', expect.any(Function));
+			});
+
+			it('Should add tawkStatusChange event listener', () => {
+				expect(typeof $tawkMessenger.onStatusChange === 'function').toBe(true);
+
+				$tawkMessenger.onStatusChange(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkStatusChange', expect.any(Function));
+			});
+
+			it('Should add tawkBeforeLoad event listener', () => {
+				expect(typeof $tawkMessenger.onBeforeLoad === 'function').toBe(true);
+
+				$tawkMessenger.onBeforeLoad(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkBeforeLoad', expect.any(Function));
+			});
+
+			it('Should add tawkChatMaximized event listener', () => {
+				expect(typeof $tawkMessenger.onChatMaximized === 'function').toBe(true);
+
+				$tawkMessenger.onChatMaximized(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMaximized', expect.any(Function));
+			});
+
+			it('Should add tawkChatMinimized event listener', () => {
+				expect(typeof $tawkMessenger.onChatMinimized === 'function').toBe(true);
+
+				$tawkMessenger.onChatMinimized(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMinimized', expect.any(Function));
+			});
+			
+			it('Should add tawkChatHidden event listener', () => {
+				expect(typeof $tawkMessenger.onChatHidden === 'function').toBe(true);
+
+				$tawkMessenger.onChatHidden(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatHidden', expect.any(Function));
+			});
+
+			it('Should add tawkChatStarted event listener', () => {
+				expect(typeof $tawkMessenger.onChatStarted === 'function').toBe(true);
+
+				$tawkMessenger.onChatStarted(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatStarted', expect.any(Function));
+			});
+			
+			it('Should add tawkChatEnded event listener', () => {
+				expect(typeof $tawkMessenger.onChatEnded === 'function').toBe(true);
+
+				$tawkMessenger.onChatEnded(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatEnded', expect.any(Function));
+			});
+
+			it('Should add tawkPrechatSubmit event listener', () => {
+				expect(typeof $tawkMessenger.onPrechatSubmit === 'function').toBe(true);
+
+				$tawkMessenger.onPrechatSubmit(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkPrechatSubmit', expect.any(Function));
+			});
+
+			it('Should add tawkOfflineSubmit event listener', () => {
+				expect(typeof $tawkMessenger.onOfflineSubmit === 'function').toBe(true);
+
+				$tawkMessenger.onOfflineSubmit(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkOfflineSubmit', expect.any(Function));
+			});
+
+			it('Should add tawkChatMessageVisitor event listener', () => {
+				expect(typeof $tawkMessenger.onChatMessageVisitor === 'function').toBe(true);
+
+				$tawkMessenger.onChatMessageVisitor(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageVisitor', expect.any(Function));
+			});
+
+			it('Should add tawkChatMessageAgent event listener', () => {
+				expect(typeof $tawkMessenger.onChatMessageAgent === 'function').toBe(true);
+
+				$tawkMessenger.onChatMessageAgent(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageAgent', expect.any(Function));
+			});
+			
+			it('Should add tawkChatMessageSystem event listener', () => {
+				expect(typeof $tawkMessenger.onChatMessageSystem === 'function').toBe(true);
+
+				$tawkMessenger.onChatMessageSystem(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatMessageSystem', expect.any(Function));
+			});
+			
+			it('Should add tawkAgentJoinChat event listener', () => {
+				expect(typeof $tawkMessenger.onAgentJoinChat === 'function').toBe(true);
+
+				$tawkMessenger.onAgentJoinChat(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkAgentJoinChat', expect.any(Function));
+			});
+
+			it('Should add tawkAgentLeaveChat event listener', () => {
+				expect(typeof $tawkMessenger.onAgentJoinChat === 'function').toBe(true);
+
+				$tawkMessenger.onAgentLeaveChat(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkAgentLeaveChat', expect.any(Function));
+			});
+			
+			it('Should add tawkChatSatisfaction event listener', () => {
+				expect(typeof $tawkMessenger.onChatSatisfaction === 'function').toBe(true);
+
+				$tawkMessenger.onChatSatisfaction(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkChatSatisfaction', expect.any(Function));
+			});
+			
+			it('Should add tawkVisitorNameChanged event listener', () => {
+				expect(typeof $tawkMessenger.onVisitorNameChanged === 'function').toBe(true);
+
+				$tawkMessenger.onVisitorNameChanged(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkVisitorNameChanged', expect.any(Function));
+			});
+
+			it('Should add tawkFileUpload event listener', () => {
+				expect(typeof $tawkMessenger.onFileUpload === 'function').toBe(true);
+
+				$tawkMessenger.onFileUpload(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkFileUpload', expect.any(Function));
+			});
+			
+			it('Should add tawkTagsUpdated event listener', () => {
+				expect(typeof $tawkMessenger.onTagsUpdated === 'function').toBe(true);
+
+				$tawkMessenger.onTagsUpdated(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkTagsUpdated', expect.any(Function));
+			});
+			
+			it('Should add tawkUnreadCountChanged event listener', () => {
+				expect(typeof $tawkMessenger.onUnreadCountChanged === 'function').toBe(true);
+
+				$tawkMessenger.onUnreadCountChanged(() => {});
+				expect(window.addEventListener).toHaveBeenCalledWith('tawkUnreadCountChanged', expect.any(Function));
+			});
 		});
 
 		it('Should set the setter functions', () => {
-			const wrapper = mountApp();
-
-			expect(typeof wrapper.vm.$tawkMessenger.visitor === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.setAttributes === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.addEvent === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.addTags === 'function').toBe(true);
-			expect(typeof wrapper.vm.$tawkMessenger.removeTags === 'function').toBe(true);
+			expect(typeof $tawkMessenger.visitor === 'function').toBe(true);
+			expect(typeof $tawkMessenger.setAttributes === 'function').toBe(true);
+			expect(typeof $tawkMessenger.addEvent === 'function').toBe(true);
+			expect(typeof $tawkMessenger.addTags === 'function').toBe(true);
+			expect(typeof $tawkMessenger.removeTags === 'function').toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
### Code Refactoring
* New way of adding event listeners to resolve [https://github.com/tawk/tawk-messenger-vue-2/issues/13](https://github.com/tawk/tawk-messenger-vue-2/issues/13)
* Update API Reference documentation
* Cleanup redundant code on test file


### BREAKING CHANGES
* Listening on events is now a callback `$tawkMessenger.onLoad(() => {})` instead of `$tawkMessenger.$on('onLoad', () => {})`.
        - This change affects the way of attaching event. Event will be added upon calling the function and the parameter function will be emit when event is triggered.