### PR TITLE
added conditional check to only initialize messenger instance once

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -19,11 +19,9 @@ function install(Vue, options = {}) {
 
 	Vue.mixin({
 		mounted() {
-			const root = new Vue();
-
-			new TawkMessenger(root, options);
-
-			Vue.prototype.$tawkMessenger = root;
+			if (!Vue.prototype.$tawkMessenger) {
+				Vue.prototype.$tawkMessenger = new TawkMessenger(this.$root, options);
+			}
 		}
 	});
 }


### PR DESCRIPTION
When installing the plugin according to the docs to a Vue SPA, the messenger instance is mounted once per component. This results in tens or even hundreds of embedded tawk scripts and eventually messes with app performance. This tiny change makes sure the messenger instance is only embedded once. 

Additionally, we changed the tawk messenger property on Vue components to hold the tawk messenger instance instead of the Vue instance, which was probably a bug, anyway.